### PR TITLE
remove organization members without a team

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,8 +121,15 @@ Team Configuration Example
 
     config = {
         "organization": {
+            # this policy decides what to do with admins that are not part of
+            # the config
             "admin_policy": EXTEND,
+            # this policy decides what to do with teams that are not part of
+            # the config
             "team_policy": EXTEND,
+            # this policy decides what to do with organization members that
+            # aren't part of a team
+            "member_policy": EXTEND,
             "admins": {
                 Admin(username="jdelic"),
             },


### PR DESCRIPTION
This removes members from the organization instead of leaving them with default
access rights, depending on the 'member_policy' in the team config.